### PR TITLE
Map before constructing the hash

### DIFF
--- a/lib/geared_pagination/portions/portion_at_cursor.rb
+++ b/lib/geared_pagination/portions/portion_at_cursor.rb
@@ -34,7 +34,7 @@ module GearedPagination
       end
 
       def orderings
-        orders.to_h { |order| [ order.attribute, order.direction ] }
+        orders.map { |order| [ order.attribute, order.direction ] }.to_h
       end
 
       def limit


### PR DESCRIPTION
to_h added support for passing a block in Ruby 2.6

https://ruby-doc.org/core-2.6/Array.html#method-i-to_h

Ruby 2.5 and earlier will raise `TypeError: wrong element type GearedPagination::Order at 0 (expected array)`