### PR TITLE
Speed up offset calculation

### DIFF
--- a/lib/geared_pagination/portions/portion_at_offset.rb
+++ b/lib/geared_pagination/portions/portion_at_offset.rb
@@ -17,7 +17,10 @@ module GearedPagination
     end
 
     def offset
-      (page_number - 1).times.sum { |index| ratios[index + 1] }
+      variable = [(page_number - 1), ratios.size - 1].min.times.sum { |index| ratios[index + 1] }
+      fixed = [page_number - ratios.size, 0].max * ratios.fixed
+
+      variable + fixed
     end
 
     def next_param(*)

--- a/lib/geared_pagination/ratios.rb
+++ b/lib/geared_pagination/ratios.rb
@@ -3,7 +3,7 @@ module GearedPagination
     DEFAULTS = [ 15, 30, 50, 100 ]
 
     def initialize(ratios = nil)
-      @ratios = Array(ratios || DEFAULTS)
+      @ratios = Array(ratios || DEFAULTS).map(&:to_i)
     end
 
     def [](page_number)

--- a/lib/geared_pagination/ratios.rb
+++ b/lib/geared_pagination/ratios.rb
@@ -7,11 +7,19 @@ module GearedPagination
     end
 
     def [](page_number)
-      @ratios[page_number - 1] || @ratios.last
+      @ratios[page_number - 1] || fixed
     end
 
     def cache_key
       @ratios.join('-')
+    end
+
+    def size
+      @ratios.size
+    end
+
+    def fixed
+      @ratios.last
     end
   end
 end

--- a/test/controller_test.rb
+++ b/test/controller_test.rb
@@ -14,6 +14,9 @@ class GearedPagination::ControllerTest < ActionController::TestCase
     assert_equal etag_for("placeholder", "page/1:1-2"), response.etag
     etag_before_gearing_change = response.etag
 
+    get :index, params: { page: 2, per_page: [ 1, 2 ] }
+    assert_equal etag_for("placeholder", "page/2:1-2"), response.etag
+
     get :index, params: { page: 1, per_page: [ 1, 2 ] }
     assert_equal etag_before_gearing_change, response.etag
 

--- a/test/portion_at_offset_test.rb
+++ b/test/portion_at_offset_test.rb
@@ -7,6 +7,9 @@ class GearedPagination::PortionAtOffsetTest < ActiveSupport::TestCase
     assert_equal 0, GearedPagination::PortionAtOffset.new(page_number: 1).offset
     assert_equal GearedPagination::Ratios::DEFAULTS.first, GearedPagination::PortionAtOffset.new(page_number: 2).offset
     assert_equal GearedPagination::Ratios::DEFAULTS.first + GearedPagination::Ratios::DEFAULTS.second, GearedPagination::PortionAtOffset.new(page_number: 3).offset
+    assert_equal 4.times.sum { |index| GearedPagination::Ratios::DEFAULTS[index] || GearedPagination::Ratios::DEFAULTS.last }, GearedPagination::PortionAtOffset.new(page_number: 5).offset
+    assert_equal 5.times.sum { |index| GearedPagination::Ratios::DEFAULTS[index] || GearedPagination::Ratios::DEFAULTS.last }, GearedPagination::PortionAtOffset.new(page_number: 6).offset
+    assert_equal 9.times.sum { |index| GearedPagination::Ratios::DEFAULTS[index] || GearedPagination::Ratios::DEFAULTS.last }, GearedPagination::PortionAtOffset.new(page_number: 10).offset
   end
 
   test "limit" do


### PR DESCRIPTION
This PR switches offset calculation from a O(2^n) implementation (where n is the number of bits used to
represent the page number) to O(1).

Before:
```
portion = GearedPagination::PortionAtOffset.new(page_number: 100000000, per_page: GearedPagination::Ratios.new)
Benchmark.bm do |x|
  x.report { portion.offset }
end

     user     system      total        real
11.741485   0.296831  12.038316 ( 12.049057)
```

After:
```
portion = GearedPagination::PortionAtOffset.new(page_number: 100000000, per_page: GearedPagination::Ratios.new)
Benchmark.bm do |x|
  x.report { portion.offset }
end

   user     system      total        real
0.000027   0.000007   0.000034 (  0.000030)
```

Apart from this, this also includes a small fix for the `per_page` parameter, as it was not working due to values there being passed to `Ratios` as strings, which means we'd always fail to calculate the offset. Tests were passing because all of them used the first page, which uses offset 0 independently of the configured ratios. With strings, and any other page > 1, a `TypeError: String can't be coerced into Integer` would be raised as we'd try to perform arithmetic operations on strings.