### PR TITLE
Introduce `before_last?` and revert `last?` behaviour

### DIFF
--- a/lib/geared_pagination/page.rb
+++ b/lib/geared_pagination/page.rb
@@ -35,7 +35,11 @@ module GearedPagination
     end
 
     def last?
-      number >= recordset.page_count
+      number == recordset.page_count
+    end
+
+    def before_last?
+      number < recordset.page_count
     end
 
 

--- a/test/page_test.rb
+++ b/test/page_test.rb
@@ -20,8 +20,13 @@ class GearedPagination::PageTest < ActiveSupport::TestCase
   end
 
   test "last with page number greater than page count" do
-    page_for_empty_set = GearedPagination::Recordset.new(Recording.none, per_page: 1000).page(2)
-    assert page_for_empty_set.last?
+    assert_not GearedPagination::Recordset.new(Recording.none, per_page: 1000).page(2).last?
+  end
+
+  test "before_last" do
+    assert     GearedPagination::Recordset.new(Recording.all, per_page:    1).page(1).before_last?
+    assert_not GearedPagination::Recordset.new(Recording.all, per_page: 1000).page(1).before_last?
+    assert_not GearedPagination::Recordset.new(Recording.none, per_page: 1000).page(2).before_last?
   end
 
   test "next offset param" do


### PR DESCRIPTION
`last?` now returns true for exactly the last page, and only for that. Pages that don't "exist", because they have numbers that are greater than the total page count, will have `last?` return false. 

`before_last?` will be false for both the last page and any non-existing pages after this one.

cc @lifo 