### PR TITLE
Ignore invalid cursor params

### DIFF
--- a/lib/geared_pagination/cursor.rb
+++ b/lib/geared_pagination/cursor.rb
@@ -6,6 +6,8 @@ module GearedPagination
     class << self
       def from_param(key)
         key.present? ? decode(key) : new
+      rescue ArgumentError, JSON::ParserError
+        new
       end
 
       def decode(key)

--- a/test/cursor_test.rb
+++ b/test/cursor_test.rb
@@ -7,6 +7,11 @@ class GearedPagination::CursorTest < ActiveSupport::TestCase
     assert_equal 1, GearedPagination::Cursor.from_param(" ").page_number
   end
 
+  test "from an invalid param" do
+    assert_equal 1, GearedPagination::Cursor.from_param("aGVsbG8K").page_number
+    assert_equal 1, GearedPagination::Cursor.from_param("\o/ not base64").page_number
+  end
+
   test "decode" do
     assert_equal 1, GearedPagination::Cursor.decode("eyJwYWdlX251bWJlciI6MX0=").page_number
   end


### PR DESCRIPTION
If a cursor param is not valid, treat it as if it's missing (rather than crashing).

An invalid param could be one that's not base64 encoded, or which is valid base64 but doesn't contain valid JSON.