### PR TITLE
API-only applications

### DIFF
--- a/lib/geared_pagination/engine.rb
+++ b/lib/geared_pagination/engine.rb
@@ -5,6 +5,7 @@ class GearedPagination::Engine < ::Rails::Engine
   initializer :geared_pagination do |app|
     ActiveSupport.on_load :action_controller do
       ActionController::Base.send :include, GearedPagination::Controller
+      ActionController::API.send :include, GearedPagination::Controller
     end
   end
 end

--- a/test/controller_test.rb
+++ b/test/controller_test.rb
@@ -40,6 +40,11 @@ class GearedPagination::ControllerTest < ActionController::TestCase
     assert_nil response.headers["Link"]
   end
 
+  test "works in both full and api only applications" do
+    assert_includes ActionController::Base.ancestors, GearedPagination::Controller
+    assert_includes ActionController::API.ancestors, GearedPagination::Controller
+  end
+
   private
     def etag_for(*keys)
       %(W/"#{ActiveSupport::Digest.hexdigest(ActiveSupport::Cache.expand_cache_key(keys))}")


### PR DESCRIPTION
Right now, this gem can only be used _out of the box_ in full applications. In order to use it in API-only applications (or in API controllers), `GearedPagination::Controller` needs to be included manually inside the controller, or an initializer.
This PR fixes it by including it manually to both `ActionController::Base` and `ActionController::API` in the engine initialization process.