### PR TITLE
Avoid another (cached) query for next link

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,19 +5,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
-
+      - uses: actions/checkout@v4
       - name: Set up Ruby 2.7
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.x
-
-      - name: Cache gem dependencies
-        uses: actions/cache@v1
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-bundler-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: ${{ runner.os }}-bundler-
+          ruby-version: '2.7'
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install libsqlite3-dev

--- a/lib/geared_pagination/page.rb
+++ b/lib/geared_pagination/page.rb
@@ -44,7 +44,7 @@ module GearedPagination
 
 
     def next_param
-      @portion.next_param recordset.records
+      @portion.next_param records
     end
 
     alias_method :next_number, :next_param

--- a/lib/geared_pagination/page.rb
+++ b/lib/geared_pagination/page.rb
@@ -44,7 +44,7 @@ module GearedPagination
 
 
     def next_param
-      @portion.next_param records
+      @portion.next_param(portion: records)
     end
 
     alias_method :next_number, :next_param

--- a/lib/geared_pagination/page.rb
+++ b/lib/geared_pagination/page.rb
@@ -44,7 +44,7 @@ module GearedPagination
 
 
     def next_param
-      @portion.next_param(portion: records)
+      @portion.next_param recordset.records
     end
 
     alias_method :next_number, :next_param

--- a/lib/geared_pagination/portions/portion_at_cursor.rb
+++ b/lib/geared_pagination/portions/portion_at_cursor.rb
@@ -21,7 +21,7 @@ module GearedPagination
 
     def next_param(scope)
       if scope.order_values.none? && scope.limit_value.nil?
-        scope = selection_from(scope).order(orderings).limit(limit)
+        scope = from(scope)
       end
 
       Cursor.encode page_number: page_number + 1, values: scope.last&.slice(*attributes) || {}

--- a/lib/geared_pagination/portions/portion_at_cursor.rb
+++ b/lib/geared_pagination/portions/portion_at_cursor.rb
@@ -19,12 +19,8 @@ module GearedPagination
       end
     end
 
-    def next_param(scope)
-      if scope.order_values.none? && scope.limit_value.nil?
-        scope = from(scope)
-      end
-
-      Cursor.encode page_number: page_number + 1, values: scope.last&.slice(*attributes) || {}
+    def next_param(scope = nil, portion: nil)
+      Cursor.encode page_number: page_number + 1, values: (portion || from(scope)).last&.slice(*attributes) || {}
     end
 
 

--- a/lib/geared_pagination/portions/portion_at_cursor.rb
+++ b/lib/geared_pagination/portions/portion_at_cursor.rb
@@ -12,15 +12,18 @@ module GearedPagination
     end
 
     def from(scope)
-      if scope.order_values.none? && scope.limit_value.nil?
-        selection_from(scope).order(orderings).limit(limit)
-      else
-        raise ArgumentError, "Can't paginate relation with ORDER BY or LIMIT clauses (got #{scope.to_sql})"
+      @froms ||= {}
+      @froms[scope] ||= begin
+        if scope.order_values.none? && scope.limit_value.nil?
+          selection_from(scope).order(orderings).limit(limit)
+        else
+          raise ArgumentError, "Can't paginate relation with ORDER BY or LIMIT clauses (got #{scope.to_sql})"
+        end
       end
     end
 
-    def next_param(scope = nil, portion: nil)
-      Cursor.encode page_number: page_number + 1, values: (portion || from(scope)).last&.slice(*attributes) || {}
+    def next_param(scope)
+      Cursor.encode page_number: page_number + 1, values: from(scope).last&.slice(*attributes) || {}
     end
 
 

--- a/lib/geared_pagination/portions/portion_at_cursor.rb
+++ b/lib/geared_pagination/portions/portion_at_cursor.rb
@@ -20,7 +20,11 @@ module GearedPagination
     end
 
     def next_param(scope)
-      Cursor.encode page_number: page_number + 1, values: from(scope).last&.slice(*attributes) || {}
+      if scope.order_values.none? && scope.limit_value.nil?
+        scope = selection_from(scope).order(orderings).limit(limit)
+      end
+
+      Cursor.encode page_number: page_number + 1, values: scope.last&.slice(*attributes) || {}
     end
 
 


### PR DESCRIPTION
`Page#records` already returns the records for the current page, so `#next_param` can use that to determine the last record for the next param, used in the `Link` header.

This is a performance optimization.

This avoids another query, albeit one that usually hits the Active Record Query Cache. The Query Cache is not always the most performant option.

cc @basecamp/sip 