### PR TITLE
Add Ruby 3.3 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3"]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,17 +10,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Ruby 2.7
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install libsqlite3-dev
+      - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install libsqlite3-dev
-
-      - name: Install gem dependencies
-        run:  gem install bundler && bundle install --jobs 4 --retry 3 --path vendor/bundle
 
       - name: Run tests
         run: bundle exec rake test


### PR DESCRIPTION
Also fixes the Ruby 2.7 run, which currently fails because of a bundler incompatibility issue.

Runs green on my fork.