### PR TITLE
Add Page#full?

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ Geared Pagination uses the ordered attributes (in the above example, `created_at
 
 Cursors encode the information Geared Pagination needs to query for the corresponding page’s records: the page number for choosing a page size, and the values of each of the ordered attributes (`created_at` and `id`).
 
+Use `@page.full?` to conditionally generate a next-page link without performing a COUNT query:
+
+```erb
+<% if @page.full? %>
+  <%= link_to "Next page", messages_path(page: @page.next_param) %>
+<% end %>
+```
+
+This may generate one extra request when the last page contains exactly as many records as its page size, but avoids counting the entire recordset.
+
 ### When should I use cursor-based pagination?
 
 Cursor-based pagination can outperform offset-based pagination when paginating deeply into a large number of records. DBs commonly execute queries with `OFFSET` clauses by counting past `OFFSET` records one at a time, so each page in offset-based pagination takes slightly longer to load than the last. With cursor-based pagination and an appropriate index, the DB can jump directly to the beginning of each page without scanning.

--- a/lib/geared_pagination/page.rb
+++ b/lib/geared_pagination/page.rb
@@ -25,6 +25,10 @@ module GearedPagination
       records.load.none?
     end
 
+    def full?
+      records.load.size == @portion.limit
+    end
+
 
     def first?
       number == 1

--- a/lib/geared_pagination/portions/portion_at_cursor.rb
+++ b/lib/geared_pagination/portions/portion_at_cursor.rb
@@ -22,6 +22,10 @@ module GearedPagination
       end
     end
 
+    def limit
+      ratios[page_number]
+    end
+
     def next_param(scope)
       Cursor.encode page_number: page_number + 1, values: from(scope).last&.slice(*attributes) || {}
     end
@@ -38,10 +42,6 @@ module GearedPagination
 
       def orderings
         orders.map { |order| [ order.attribute, order.direction ] }.to_h
-      end
-
-      def limit
-        ratios[page_number]
       end
 
       def attributes

--- a/test/page_test.rb
+++ b/test/page_test.rb
@@ -29,6 +29,18 @@ class GearedPagination::PageTest < ActiveSupport::TestCase
     assert_not GearedPagination::Recordset.new(Recording.none, per_page: 1000).page(2).before_last?
   end
 
+  test "full" do
+    assert     GearedPagination::Recordset.new(Recording.all, per_page:    1).page(1).full?
+    assert     GearedPagination::Recordset.new(Recording.all, per_page:  120).page(1).full?
+    assert_not GearedPagination::Recordset.new(Recording.all, per_page: 1000).page(1).full?
+  end
+
+  test "full by cursor" do
+    assert     GearedPagination::Recordset.new(Recording.all, ordered_by: :number, per_page:   15).page(cursor).full?
+    assert     GearedPagination::Recordset.new(Recording.all, ordered_by: :number, per_page:  120).page(cursor).full?
+    assert_not GearedPagination::Recordset.new(Recording.all, ordered_by: :number, per_page: 1000).page(cursor).full?
+  end
+
   test "next offset param" do
     assert_equal 2, GearedPagination::Recordset.new(Recording.all, per_page: 1000).page(1).next_param
   end
@@ -60,6 +72,10 @@ class GearedPagination::PageTest < ActiveSupport::TestCase
   end
 
   private
+    def cursor
+      GearedPagination::Cursor.encode(page_number: 1)
+    end
+
     def cache_key(page:, per_page:)
       GearedPagination::Recordset.new(Recording.all, per_page: per_page).page(page).cache_key
     end


### PR DESCRIPTION
Adds `GearedPagination::Page#full?`, which checks whether the current page returned as many records as its page size.

This is useful for conditionally rendering the next-page link without performing a COUNT query when using cursor-based pagination.

The tradeoff is that a final page containing exactly the page size may still render a next-page link, causing one extra request.